### PR TITLE
Fix Firebase DB import path

### DIFF
--- a/assets/js/firebase/auth-ui.js
+++ b/assets/js/firebase/auth-ui.js
@@ -1,5 +1,5 @@
 import { login, register } from './auth.js';
-import { db } from './firebase/app.js';
+import { db } from './app.js';
 import { doc, setDoc } from "firebase/firestore";
 
 export function setupAuthUI() {


### PR DESCRIPTION
## Summary
- fix path to Firebase `app.js` in auth UI

## Testing
- `node -e "import('./assets/js/firebase/auth-ui.js').catch(e=>console.error(e))"`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a402cb093c83238fddbb0ad48061e8